### PR TITLE
Bootstrap iOS Foveto app with core models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "Foveto",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "FovetoCore", targets: ["FovetoCore"])
+    ],
+    targets: [
+        .target(name: "FovetoCore"),
+        .testTarget(name: "FovetoCoreTests", dependencies: ["FovetoCore"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Foveto
+# Foveto iOS MVP
+
+Starter project for the Foveto concept. The repository contains:
+
+- **FovetoCore** – pure Swift package with event model and metric helpers.
+- **iOSApp** – SwiftUI starter using glass effects and tab navigation for Home, Track, Reflect, Guide and Ship sections.
+
+## Build
+
+```
+# run unit tests for the core package
+swift test
+```
+
+Open `iOSApp` in Xcode 15 or later and run on iOS 17+.

--- a/Sources/FovetoCore/Event.swift
+++ b/Sources/FovetoCore/Event.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+public struct Event: Identifiable, Codable {
+    public let id: UUID
+    public var userID: UUID
+    public var timestampStart: Date
+    public var timestampEnd: Date
+    public var source: Source
+    public var category: Category
+    public var tags: [String]
+    public var note: String?
+    public var intensity: Int
+    public var context: Context
+    public var confidence: Double
+
+    public init(
+        id: UUID = UUID(),
+        userID: UUID,
+        timestampStart: Date,
+        timestampEnd: Date,
+        source: Source,
+        category: Category,
+        tags: [String] = [],
+        note: String? = nil,
+        intensity: Int = 1,
+        context: Context = Context(device: "unknown", location: nil),
+        confidence: Double = 1.0
+    ) {
+        self.id = id
+        self.userID = userID
+        self.timestampStart = timestampStart
+        self.timestampEnd = timestampEnd
+        self.source = source
+        self.category = category
+        self.tags = tags
+        self.note = note
+        self.intensity = intensity
+        self.context = context
+        self.confidence = confidence
+    }
+
+    public enum Source: String, Codable {
+        case app
+        case browser
+        case manual
+    }
+
+    public enum Category: String, Codable, CaseIterable {
+        case scroll
+        case switchBurst = "switch"
+        case study
+        case workout
+        case sleep
+        case social
+        case toxic
+        case deepWork = "deep_work"
+        case admin
+        case breakTime = "break"
+        case meal
+        case walk
+        case meditate
+        case contentCreate = "content_create"
+    }
+
+    public struct Context: Codable {
+        public var device: String
+        public var location: String?
+
+        public init(device: String, location: String? = nil) {
+            self.device = device
+            self.location = location
+        }
+    }
+}
+
+public extension Event {
+    var duration: TimeInterval {
+        timestampEnd.timeIntervalSince(timestampStart)
+    }
+}

--- a/Sources/FovetoCore/Metrics.swift
+++ b/Sources/FovetoCore/Metrics.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum Metrics {
+    public static func dopamineLoad(for events: [Event]) -> Double {
+        events.reduce(0) { sum, event in
+            let weight = dopamineWeight(for: event.category)
+            return sum + weight * event.duration/60.0 * Double(event.intensity)
+        }
+    }
+
+    public static func energyScore(baseFromSleep: Double, gains: Double, drains: Double) -> Double {
+        baseFromSleep + gains - drains
+    }
+
+    public static func focusIntegrity(goalTime: TimeInterval, distractionTime: TimeInterval) -> Double {
+        let total = goalTime + distractionTime
+        guard total > 0 else { return 0 }
+        return goalTime / total
+    }
+
+    private static func dopamineWeight(for category: Event.Category) -> Double {
+        switch category {
+        case .scroll: return 1.0
+        case .switchBurst: return 0.6
+        case .toxic: return 0.7
+        case .social: return 0.5
+        default: return 0.0
+        }
+    }
+}

--- a/Tests/FovetoCoreTests/MetricsTests.swift
+++ b/Tests/FovetoCoreTests/MetricsTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import FovetoCore
+
+final class MetricsTests: XCTestCase {
+    func testDopamineLoad() {
+        let user = UUID()
+        let start = Date()
+        let end = start.addingTimeInterval(600) // 10m
+        let events = [
+            Event(userID: user, timestampStart: start, timestampEnd: end, source: .app, category: .scroll, intensity: 1)
+        ]
+        XCTAssertEqual(Metrics.dopamineLoad(for: events), 10.0, accuracy: 0.001)
+    }
+
+    func testFocusIntegrity() {
+        let fi = Metrics.focusIntegrity(goalTime: 50, distractionTime: 25)
+        XCTAssertEqual(fi, 0.666, accuracy: 0.001)
+    }
+}

--- a/iOSApp/Components/GlassBackground.swift
+++ b/iOSApp/Components/GlassBackground.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct GlassBackground<Content: View>: View {
+    var blurStyle: Material = .ultraThin
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        content
+            .padding()
+            .background(blurStyle, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(Color.white.opacity(0.3), lineWidth: 1)
+            )
+    }
+}

--- a/iOSApp/ContentView.swift
+++ b/iOSApp/ContentView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem { Label("Home", systemImage: "house.fill") }
+            TrackView()
+                .tabItem { Label("Track", systemImage: "timer") }
+            ReflectView()
+                .tabItem { Label("Reflect", systemImage: "chart.bar.xaxis") }
+            GuideView()
+                .tabItem { Label("Guide", systemImage: "lightbulb") }
+            ShipView()
+                .tabItem { Label("Ship", systemImage: "paperplane") }
+        }
+        .tint(.teal)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/iOSApp/FovetoApp.swift
+++ b/iOSApp/FovetoApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import FovetoCore
+
+@main
+struct FovetoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/iOSApp/Views/GuideView.swift
+++ b/iOSApp/Views/GuideView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct GuideView: View {
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    ActionCard(title: "3‑min breath", subtitle: "+3 ES • 3 min", icon: "wind")
+                    ActionCard(title: "Mute Discord", subtitle: "Patch distraction", icon: "bell.slash")
+                    ActionCard(title: "Write 3 hooks", subtitle: "Ship in 5 min", icon: "pencil.and.outline")
+                }
+                .padding()
+            }
+            .navigationTitle("Guide")
+        }
+    }
+}
+
+struct ActionCard: View {
+    var title: String
+    var subtitle: String
+    var icon: String
+
+    var body: some View {
+        GlassBackground {
+            HStack {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .frame(width: 32)
+                VStack(alignment: .leading) {
+                    Text(title).font(.headline)
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Do") {}
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+#Preview {
+    GuideView()
+}

--- a/iOSApp/Views/HomeView.swift
+++ b/iOSApp/Views/HomeView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import FovetoCore
+
+struct HomeView: View {
+    @State private var energy: Double = 0.6
+    @State private var dopamine: Double = 0.4
+    @State private var focus: Double = 0.5
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Image("home-bg")
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
+
+                VStack(spacing: 24) {
+                    GlassBackground {
+                        VStack {
+                            HStack {
+                                StatView(title: "Energy", value: energy)
+                                StatView(title: "Dopamine", value: dopamine)
+                                StatView(title: "Focus", value: focus)
+                            }
+                        }
+                    }
+                    .animation(.easeInOut(duration: 0.3), value: energy)
+
+                    GlassBackground {
+                        HStack {
+                            Button(action: {}) { Label("Log", systemImage: "plus") }
+                            Spacer()
+                            Button(action: {}) { Label("Focus", systemImage: "target") }
+                            Spacer()
+                            Button(action: {}) { Label("Ship", systemImage: "paperplane") }
+                        }
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    }
+                    Spacer()
+                }
+                .padding()
+            }
+            .navigationTitle("Today")
+        }
+    }
+}
+
+struct StatView: View {
+    var title: String
+    var value: Double
+
+    var body: some View {
+        VStack {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(Int(value * 100), format: .number)
+                .font(.title2.bold())
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/iOSApp/Views/ReflectView.swift
+++ b/iOSApp/Views/ReflectView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ReflectView: View {
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    GlassBackground {
+                        VStack(alignment: .leading) {
+                            Text("Top Drains")
+                                .font(.headline)
+                            Text("No data yet")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    GlassBackground {
+                        VStack(alignment: .leading) {
+                            Text("Top Gains")
+                                .font(.headline)
+                            Text("No data yet")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Reflect")
+        }
+    }
+}
+
+#Preview {
+    ReflectView()
+}

--- a/iOSApp/Views/ShipView.swift
+++ b/iOSApp/Views/ShipView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ShipView: View {
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                GlassBackground {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Create a tiny release")
+                            .font(.headline)
+                        Button("Attach Artifact") {}
+                            .buttonStyle(.bordered)
+                        Button("Ship Now") {}
+                            .buttonStyle(.borderedProminent)
+                    }
+                }
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Ship")
+        }
+    }
+}
+
+#Preview {
+    ShipView()
+}

--- a/iOSApp/Views/TrackView.swift
+++ b/iOSApp/Views/TrackView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct TrackView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Today") {
+                    Text("No events yet")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Track")
+        }
+    }
+}
+
+#Preview {
+    TrackView()
+}


### PR DESCRIPTION
## Summary
- add `FovetoCore` Swift package with `Event` model and metric helpers
- scaffold SwiftUI app featuring glass cards and tab navigation for Home, Track, Reflect, Guide and Ship
- include unit tests for core metrics

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6899137144cc83279c5d282367bcc618